### PR TITLE
Endpoint de alta performance de datos basicos de un contenido 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import org.jetbrains.kotlin.util.findImplementationFromInterface
 
 plugins {
 	id("org.springframework.boot") version "2.4.4"
@@ -30,7 +29,6 @@ dependencies {
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-	developmentOnly("org.springframework.boot:spring-boot-devtools")
 	runtimeOnly("com.h2database:h2")
 	providedRuntime("org.springframework.boot:spring-boot-starter-tomcat")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
@@ -39,7 +37,7 @@ dependencies {
 	implementation("io.springfox:springfox-swagger-ui:2.9.2")
 	implementation("commons-validator:commons-validator:1.4.1")
 	implementation("io.jsonwebtoken:jjwt:0.9.1")
-
+	implementation("org.springframework.boot:spring-boot-starter-data-redis")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/BackendDesappApiApplication.kt
+++ b/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/BackendDesappApiApplication.kt
@@ -3,9 +3,11 @@ package ar.edu.unq.grupoN.backenddesappapi
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
 import org.springframework.boot.runApplication
+import org.springframework.cache.annotation.EnableCaching
 
 
 @SpringBootApplication(exclude = [SecurityAutoConfiguration::class])
+@EnableCaching
 class BackendDesappApiApplication
 
 

--- a/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/model/imdb/CinematographicContent.kt
+++ b/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/model/imdb/CinematographicContent.kt
@@ -1,7 +1,7 @@
 package ar.edu.unq.grupoN.backenddesappapi.model.imdb
 
 import ar.edu.unq.grupoN.backenddesappapi.model.BasicInformation
-import ar.edu.unq.grupoN.backenddesappapi.model.RatingInfo
+import ar.edu.unq.grupoN.backenddesappapi.model.review.Review
 import javax.persistence.*
 
 @Entity
@@ -19,15 +19,20 @@ abstract class CinematographicContent(){
     open var cast: MutableList<CastMember> = mutableListOf()
     open var averageRating: Double = 0.0
     open var votesAmount: Int = 0
+    open var sumVotes: Double = 0.0
 
-    constructor(basicInformation: BasicInformation, cast: MutableList<CastMember>, rating: RatingInfo): this(){
+    constructor(basicInformation: BasicInformation, cast: MutableList<CastMember>): this(){
         this.cast = cast
         set_basic_information(basicInformation)
-        set_rating(rating)
-
     }
 
     open fun isSerie() = false
+
+    fun addRate(review: Review) {
+        votesAmount += 1
+        sumVotes += review.rating
+        averageRating = sumVotes / votesAmount
+    }
 
     private fun set_basic_information(basicInformation: BasicInformation) {
         this.titleId = basicInformation.titleId
@@ -36,11 +41,6 @@ abstract class CinematographicContent(){
         this.isAdultContent = basicInformation.isAdultContent
         this.startYear = basicInformation.startYear
         this.runtimeMinutes = basicInformation.runtimeMinutes
-    }
-
-    private fun set_rating(rating: RatingInfo) {
-        this.averageRating = rating.averageRating
-        this.votesAmount = rating.votesAmount
     }
 
     open fun haveEpisode(seasonNumber: Int?, episodeNumber: Int?) = false

--- a/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/model/imdb/Movie.kt
+++ b/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/model/imdb/Movie.kt
@@ -1,11 +1,10 @@
 package ar.edu.unq.grupoN.backenddesappapi.model.imdb
 
 import ar.edu.unq.grupoN.backenddesappapi.model.BasicInformation
-import ar.edu.unq.grupoN.backenddesappapi.model.RatingInfo
 import javax.persistence.Entity
 import javax.persistence.PrimaryKeyJoinColumn
 
 @Entity
 @PrimaryKeyJoinColumn(name="titleId")
-class Movie(basicInformation: BasicInformation, cast: MutableList<CastMember>, rating: RatingInfo)
-    : CinematographicContent(basicInformation, cast, rating)
+class Movie(basicInformation: BasicInformation, cast: MutableList<CastMember>)
+    : CinematographicContent(basicInformation, cast)

--- a/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/model/imdb/Serie.kt
+++ b/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/model/imdb/Serie.kt
@@ -1,7 +1,6 @@
 package ar.edu.unq.grupoN.backenddesappapi.model.imdb
 
 import ar.edu.unq.grupoN.backenddesappapi.model.BasicInformation
-import ar.edu.unq.grupoN.backenddesappapi.model.RatingInfo
 import ar.edu.unq.grupoN.backenddesappapi.model.SerieInfo
 import javax.persistence.*
 
@@ -10,9 +9,8 @@ import javax.persistence.*
 class Serie(
     basicInformation: BasicInformation,
     cast: MutableList<CastMember>,
-    rating: RatingInfo,
     serieInfo: SerieInfo
-) :  CinematographicContent(basicInformation, cast, rating){
+) :  CinematographicContent(basicInformation, cast){
 
     var endYear: Int? = null
 

--- a/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/persistence/CinematographicContentRepository.kt
+++ b/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/persistence/CinematographicContentRepository.kt
@@ -8,5 +8,4 @@ import org.springframework.stereotype.Repository
 
 @Repository
 @Configuration
-interface CinematographicContentRepository : CrudRepository<CinematographicContent, String?> {
-}
+interface CinematographicContentRepository : CrudRepository<CinematographicContent, String?>

--- a/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/persistence/PerformedContentRepository.kt
+++ b/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/persistence/PerformedContentRepository.kt
@@ -1,0 +1,8 @@
+package ar.edu.unq.grupoN.backenddesappapi.persistence
+
+import ar.edu.unq.grupoN.backenddesappapi.service.PerformedContent
+import org.springframework.data.repository.CrudRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface PerformedContentRepository: CrudRepository<PerformedContent, String?>

--- a/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/persistence/ReviewRepositoryCustomImpl.kt
+++ b/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/persistence/ReviewRepositoryCustomImpl.kt
@@ -49,11 +49,12 @@ class ReviewRepositoryCustomImpl : ReviewRepositoryCustom {
 
         val predicates: MutableList<Predicate> = ArrayList()
 
-        if (reverseSearchFilter.reviewRating != null) {
-            val predicate = cb.greaterThanOrEqualTo(review.get("rating"), reverseSearchFilter.reviewRating)
-            predicates.add(predicate)
+        filterAverageRating(reverseSearchFilter, cb, reviewAndContent, predicates)
+
+        if (reverseSearchFilter.genre != null){
+            addEqual(predicates, cb, cb.upper(reviewAndContent.get("titleType")), reverseSearchFilter.genre.toUpperCase())
         }
-        addEqual(predicates, cb, cb.upper(reviewAndContent.get("titleType")), reverseSearchFilter.genre?.toUpperCase())
+
         filterWellValued(predicates, cb, reverseSearchFilter.wellValued, review)
         filterDecade(predicates, cb, reverseSearchFilter, reviewAndContent)
         filterIsAdultContent(predicates, cb, reverseSearchFilter.isAdultContent, reviewAndContent)
@@ -68,6 +69,18 @@ class ReviewRepositoryCustomImpl : ReviewRepositoryCustom {
 
         return query.resultList
 
+    }
+
+    private fun filterAverageRating(
+        reverseSearchFilter: ReverseSearchFilter,
+        cb: CriteriaBuilder,
+        reviewAndContent: Join<Review, CinematographicContent>,
+        predicates: MutableList<Predicate>
+    ) {
+        if (reverseSearchFilter.rating != null) {
+            val predicate = cb.greaterThanOrEqualTo(reviewAndContent.get("averageRating"), reverseSearchFilter.rating)
+            predicates.add(predicate)
+        }
     }
 
     private fun generateReviewFilters(

--- a/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/service/CinematographicContentService.kt
+++ b/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/service/CinematographicContentService.kt
@@ -2,6 +2,7 @@ package ar.edu.unq.grupoN.backenddesappapi.service
 
 import ar.edu.unq.grupoN.backenddesappapi.model.imdb.CinematographicContent
 import ar.edu.unq.grupoN.backenddesappapi.persistence.CinematographicContentRepository
+import ar.edu.unq.grupoN.backenddesappapi.persistence.PerformedContentRepository
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -13,13 +14,17 @@ class CinematographicContentService {
     @Autowired
     private lateinit var repository: CinematographicContentRepository
 
+    @Autowired
+    private lateinit var performedContentRepository: PerformedContentRepository
+
     @Transactional
     fun findById(titleId: String): Optional<CinematographicContent> {
         return repository.findById(titleId)
     }
 
     @Transactional
-    open fun add(cinematographicContent: CinematographicContent): CinematographicContent {
+    fun add(cinematographicContent: CinematographicContent): CinematographicContent {
+        performedContentRepository.save(PerformedContent.from(cinematographicContent))
         return repository.save(cinematographicContent)
     }
 

--- a/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/service/dto/CinematographicContentDTO.kt
+++ b/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/service/dto/CinematographicContentDTO.kt
@@ -1,10 +1,8 @@
 package ar.edu.unq.grupoN.backenddesappapi.service.dto
 
-import ar.edu.unq.grupoN.backenddesappapi.model.imdb.CastMember
-import ar.edu.unq.grupoN.backenddesappapi.model.imdb.CinematographicContent
-import ar.edu.unq.grupoN.backenddesappapi.model.imdb.Season
-import ar.edu.unq.grupoN.backenddesappapi.model.imdb.Serie
 import ar.edu.unq.grupoN.backenddesappapi.model.Employment
+import ar.edu.unq.grupoN.backenddesappapi.model.imdb.CinematographicContent
+import ar.edu.unq.grupoN.backenddesappapi.model.imdb.Serie
 
 abstract class CinematographicContentDTO{
     companion object {

--- a/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/service/dto/Filters.kt
+++ b/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/service/dto/Filters.kt
@@ -19,7 +19,7 @@ data class ApplicableFilters(
 )
 
 data class ReverseSearchFilter(
-    val reviewRating: Double? = null,
+    val rating: Double? = null,
     val wellValued: Boolean? = null,
     val genre: String? = null,
     val decade: Int? = null,

--- a/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/webservice/config/CacheConfig.kt
+++ b/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/webservice/config/CacheConfig.kt
@@ -1,0 +1,34 @@
+package ar.edu.unq.grupoN.backenddesappapi.webservice.config
+
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.CachingConfigurerSupport
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+
+
+@Configuration
+class CacheConfig : CachingConfigurerSupport() {
+
+    @Bean
+    fun cacheManager(redisConnectionFactory: RedisConnectionFactory?): CacheManager {
+        val redisCacheConfigurationMap: MutableMap<String, RedisCacheConfiguration> = HashMap()
+        redisCacheConfigurationMap[CONTENT_CACHE] = createConfig(30, ChronoUnit.SECONDS)
+        return RedisCacheManager
+            .builder(redisConnectionFactory!!)
+            .withInitialCacheConfigurations(redisCacheConfigurationMap)
+            .build()
+    }
+
+    companion object {
+        const val CONTENT_CACHE = "fast-content"
+        private fun createConfig(time: Long, temporalUnit: ChronoUnit): RedisCacheConfiguration {
+            return RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.of(time, temporalUnit))
+        }
+    }
+}

--- a/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/webservice/config/FakeDataConfiguration.kt
+++ b/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/webservice/config/FakeDataConfiguration.kt
@@ -8,6 +8,8 @@ import ar.edu.unq.grupoN.backenddesappapi.service.CinematographicContentService
 import ar.edu.unq.grupoN.backenddesappapi.service.PlatformAdminService
 import ar.edu.unq.grupoN.backenddesappapi.service.ReviewService
 import ar.edu.unq.grupoN.backenddesappapi.service.dto.RegisterRequest
+import ar.edu.unq.grupoN.backenddesappapi.service.dto.ReviewDTO
+import ar.edu.unq.grupoN.backenddesappapi.webservice.controllers.CreateReviewRequest
 import com.github.javafaker.Faker
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.CommandLineRunner
@@ -63,7 +65,6 @@ class FakeDataConfiguration {
                 Serie(
                     basicInformation = getBasicInformation(),
                     cast = getCastMembers(5),
-                    rating = getRatingInfo(),
                     serieInfo = serieInfo
                 )
 
@@ -87,7 +88,6 @@ class FakeDataConfiguration {
                 Movie(
                     basicInformation = getBasicInformation(),
                     cast = getCastMembers(faker.number().numberBetween(5, 8)),
-                    rating = getRatingInfo()
                 )
 
             cinematographicContentService.add(newMovie)
@@ -126,11 +126,6 @@ class FakeDataConfiguration {
         }
         return cast
     }
-
-    private fun getRatingInfo() = RatingInfo(
-        averageRating = faker.number().randomDouble(2, 3, 10),
-        votesAmount = faker.number().numberBetween(2, 9999989)
-    )
 
     private fun genericCastMember(name: String, employment: Employment): CastMember {
         return CastMember(
@@ -191,8 +186,11 @@ class FakeDataConfiguration {
                 )
             }
 
-            reviewService.addFakeReview(publicReview)
-            reviewService.addFakeReview(premiumReview)
+            val createPublicReviewRequest = CreateReviewRequest(content.titleId, ReviewDTO.fromModel(publicReview))
+            reviewService.saveReview(createPublicReviewRequest)
+
+            val createPremiumReviewRequest = CreateReviewRequest(content.titleId, ReviewDTO.fromModel(premiumReview))
+            reviewService.saveReview(createPremiumReviewRequest)
 
         }
     }
@@ -207,7 +205,6 @@ class FakeDataConfiguration {
             Movie(
                 basicInformation = getBasicInformation(),
                 cast = cast,
-                rating = getRatingInfo()
             )
 
         val reviewInfo = ReviewInfo(
@@ -237,7 +234,8 @@ class FakeDataConfiguration {
         publicReview.id = 1
 
         cinematographicContentService.add(gladiatorMovie)
-        reviewService.addFakeReview(publicReview)
+        val createReviewRequest = CreateReviewRequest("GladiatorID", ReviewDTO.fromModel(publicReview))
+        reviewService.saveReview(createReviewRequest)
 
     }
 }

--- a/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/webservice/config/RedisConfig.kt
+++ b/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/webservice/config/RedisConfig.kt
@@ -1,0 +1,24 @@
+package ar.edu.unq.grupoN.backenddesappapi.webservice.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+
+
+@Bean
+fun jedisConnectionFactory(): JedisConnectionFactory {
+    val redisStandaloneConfiguration =
+        RedisStandaloneConfiguration(
+            System.getenv().getOrDefault("REDIS_URL", "localhost"),
+            6379
+        )
+    return JedisConnectionFactory(redisStandaloneConfiguration)
+}
+
+@Bean
+fun redisTemplate(): RedisTemplate<String, Any> {
+    val template = RedisTemplate<String, Any>()
+    template.setConnectionFactory(jedisConnectionFactory())
+    return template
+}

--- a/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/webservice/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/webservice/config/security/SecurityConfig.kt
@@ -12,7 +12,6 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.CorsConfigurationSource
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource
-import javax.servlet.http.HttpServletRequest
 
 
 @Configuration

--- a/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/webservice/controllers/PlatformAdminController.kt
+++ b/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/webservice/controllers/PlatformAdminController.kt
@@ -3,7 +3,6 @@ package ar.edu.unq.grupoN.backenddesappapi.webservice.controllers
 import ar.edu.unq.grupoN.backenddesappapi.service.PlatformAdminService
 import ar.edu.unq.grupoN.backenddesappapi.service.dto.LoginCredentialsRequest
 import ar.edu.unq.grupoN.backenddesappapi.service.dto.RegisterRequest
-import io.jsonwebtoken.Jwts
 import io.swagger.annotations.ApiOperation
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration

--- a/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/webservice/controllers/ReviewController.kt
+++ b/src/main/kotlin/ar/edu/unq/grupoN/backenddesappapi/webservice/controllers/ReviewController.kt
@@ -45,7 +45,6 @@ class ReviewController {
             ApiResponse(code = 400, message = "Bad request in fields")]
     )
     @RequestMapping(value = ["/add"], method = [RequestMethod.POST])
-    @Authorize
     fun addReview(@RequestBody createReviewRequest: CreateReviewRequest): ResponseEntity<*>? {
         return ResponseEntity.ok(reviewService.saveReview(createReviewRequest))
     }
@@ -81,7 +80,7 @@ class ReviewController {
         @PathVariable reviewId: Long,
         @RequestBody reportDTO: ReportDTO
     )
-    : ResponseEntity<*>? {
+            : ResponseEntity<*>? {
         return ResponseEntity.ok(reviewService.report(reviewId, reportDTO))
     }
 
@@ -171,6 +170,15 @@ class ReviewController {
             reviewRating, wellValued, genre, decade, isAdultContent, searchCastMember, jobInContent
         )
         return ResponseEntity.ok(reviewService.findContentBy(reverseSearchFilter))
+    }
+
+    @RequestMapping(value = ["/fastContent"], method = [RequestMethod.GET])
+    fun performantContentSearch(
+        @ApiParam(example = "GladiatorID")
+        @RequestParam titleId: String
+    ): ResponseEntity<*>? {
+
+        return ResponseEntity.ok(reviewService.performedSearchFor(titleId))
     }
 
     @ApiOperation(value = "Endpoint used for api develop. to show generated fake reviews", hidden = true)

--- a/src/test/kotlin/ar/edu/unq/grupoN/backenddesappapi/Factory.kt
+++ b/src/test/kotlin/ar/edu/unq/grupoN/backenddesappapi/Factory.kt
@@ -58,9 +58,8 @@ class Factory {
             "SPTKSukq4sk893", "Spartacus",
             titleType, isAdult, 2010, runtimeMinutes
         )
-        val rating = RatingInfo(averageRating, numVotes)
         val serieInfo = SerieInfo(2013, listOf())
-        val spartacus = Serie(basicInformation, cast, rating, serieInfo)
+        val spartacus = Serie(basicInformation, cast, serieInfo)
         spartacus.seasons = listOf(seasons)
         spartacus.endYear = 2013
 
@@ -72,17 +71,14 @@ class Factory {
             "GLADIIiiatoor45", "Gladiator",
             titleType, isAdult, startYear, runtimeMinutes
         )
-        val rating = RatingInfo(averageRating, numVotes)
-
-        return Movie(basicInformation, cast, rating)
+        return Movie(basicInformation, cast)
     }
 
     fun genericCastMember(): CastMember {
-        val russell = CastMember(
+        return CastMember(
             "Russell Crowe", Employment.ACTOR,
             null, "Maximus", 9999, 9999
         )
-        return russell
     }
 
     //Objects atibutes

--- a/src/test/kotlin/ar/edu/unq/grupoN/backenddesappapi/model/imdb/CinematographicContentTest.kt
+++ b/src/test/kotlin/ar/edu/unq/grupoN/backenddesappapi/model/imdb/CinematographicContentTest.kt
@@ -32,6 +32,27 @@ class CinematographicContentTest {
             .isEqualTo(listOf(season))
     }
 
+    @Test
+    fun `a content can be rated by a review and obtain one more votes amount`(){
+        val votesBeforeRate = gladiator.votesAmount
+
+        gladiator.addRate(factory.aPublicReview())
+
+        assertThat(gladiator.votesAmount).isEqualTo(votesBeforeRate + 1)
+    }
+
+    @Test
+    fun `a content can be rated by a review have new rating and sum votes`(){
+        val sumVotesBeforeRate = gladiator.sumVotes
+        val ratingBeforeRate = gladiator.sumVotes
+
+        gladiator.addRate(factory.aPublicReview())
+        gladiator.addRate(factory.aPublicReview())
+
+        assertThat(gladiator.sumVotes).isEqualTo(sumVotesBeforeRate + 3 + 3)
+        assertThat(gladiator.averageRating).isEqualTo(ratingBeforeRate + 3)
+    }
+
     private fun a_season(): Season {
         val episode = Episode(1)
         episode.id = 3


### PR DESCRIPTION
:sparkles: Redis como herramienta performante de endpoint de contenido con datos basicos
:sparkles: nueva entidad para obtener los datos de un contenido de forma inmediata en el modelo relacional
:art: ahora el filtrado por promedio es del contenido en vez de la review.
:art: varios renames y optimizacion de crear contenidos
:art: optimizacion de imports

-nota: no va a funcionar el deploy de heroku porque no va a tener Redis configurado, pero levantando redis local anda joya